### PR TITLE
FIX: Update error message variables in PHP form

### DIFF
--- a/7-PHP-avanzado/4-proyecto/app/views/newpost.view.php
+++ b/7-PHP-avanzado/4-proyecto/app/views/newpost.view.php
@@ -58,7 +58,7 @@
                                 class="u-border-2 u-border-black u-border-no-left u-border-no-right u-border-no-top u-input u-input-rectangle"
                                 autofocus>
                             <span class="error">
-                                <?php echo $userError; ?>
+                                <?php echo $titleError; ?>
                             </span>
                         </div>
                         <div class="u-form-email u-form-group u-label-top">
@@ -66,7 +66,7 @@
                             <input type="text" placeholder="Extracto del artículo" id="email-5a14" name="summary"
                                 class="u-border-2 u-border-black u-border-no-left u-border-no-right u-border-no-top u-input u-input-rectangle">
                             <span class="error">
-                                <?php echo $userError; ?>
+                                <?php echo $summaryError; ?>
                             </span>
                         </div>
                         <div class="u-form-group u-form-message u-label-top">
@@ -75,7 +75,7 @@
                                 name="post"
                                 class="u-border-2 u-border-black u-border-no-left u-border-no-right u-border-no-top u-input u-input-rectangle"></textarea>
                             <span class="error">
-                                <?php echo $userError; ?>
+                                <?php echo $postError; ?>
                             </span>
                         </div>
                         <div class="u-align-right u-form-group u-form-submit u-label-top">


### PR DESCRIPTION
# Description:
This pull request addresses the need to update error messages in the PHP code for a form. The original code contained references to the $userError variable for error messages, which was not appropriate for all fields in the form. To improve the user experience and ensure that error messages are displayed correctly for each input field, this pull request makes the following changes:

## Title Input Field:
- Replaced $userError with $titleError for the title input field error message.
- Updated the error message in the title input field to display $titleError instead of $userError.

## Summary Input Field:
- Replaced $userError with $summaryError for the summary input field error message.
- Updated the error message in the summary input field to display $summaryError instead of $userError.

## Post Textarea Input Field:
- Replaced $userError with $postError for the post textarea input field error message.
- Updated the error message in the post textarea input field to display $postError instead of $userError.

These changes ensure that the error messages are associated with the correct input fields in the form, enhancing the clarity and usability of the form for users. It also helps maintain code consistency and readability.

# Testing:
Before submitting this pull request, I thoroughly tested the modified code to ensure that error messages are displayed correctly for each input field in the form. I verified that the appropriate error variables are used and that error messages are shown when needed. The form functionality remains intact after these changes.

# Additional Notes:
This pull request is part of an ongoing effort to improve code quality and maintainability. It aligns with best practices for form validation and error handling in PHP, making the codebase more robust and user-friendly.

Please review and consider merging this pull request. Your feedback and suggestions are welcome.